### PR TITLE
Change the underscore '_' in the command to a dash '-'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OpenPerf is equipped with a CLI for easy execution of benchmarks. Here’s how y
 ### Running Data Science Benchmarks
 To run the bot detection benchmark, which helps understand automated interactions in project management:
 ```bash
-openperf data_science bot_detection
+openperf data-science bot-detection
 ```
 
 ### Running Standard Benchmarks


### PR DESCRIPTION
According to this command, `openperf data_science bot_detection`，the output is

```
PS F:\open-perf> openperf data_science bot_detection
Available commands: ['data-science', 'index', 'standard']
Usage: openperf [OPTIONS] COMMAND [ARGS]...
Try 'openperf --help' for help.

Error: No such command 'data_science'.
```

After all modifications, it can run successfully

```
PS F:\open-perf> openperf data-science bot-detection
Available commands: ['data-science', 'index', 'standard']
Running bot detection benchmark. Please wait...
D:\Program Files\anaconda\envs\openperf\lib\site-packages\openperf\benchmarks\data_science\bot_detection\bench.py:68: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  df['label'] = df['label'].replace(bot_mapping)
training DecisionTree
Using parameters for DecisionTree: {'max_depth': [3, 5, 7], 'min_samples_split': [2, 4, 8]}
training KNeighbors
Using parameters for KNeighbors: {'n_neighbors': [3, 5, 7], 'weights': ['uniform', 'distance']}
training RandomForest
Using parameters for RandomForest: {'n_estimators': [10, 50, 100], 'max_depth': [3, 5, 7]}
```

Perhaps because when click converts a function into a command, it automatically converts the underscore "_" in the function name to a dash "-"